### PR TITLE
Add DocumentType decoder

### DIFF
--- a/src/main/java/th/ac/kmitl/soa/group2/definitions/DocumentType.java
+++ b/src/main/java/th/ac/kmitl/soa/group2/definitions/DocumentType.java
@@ -1,33 +1,50 @@
 package th.ac.kmitl.soa.group2.definitions;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vavr.collection.List;
-import io.vavr.control.Option;
 import lombok.RequiredArgsConstructor;
+
+import static java.lang.String.format;
 
 @RequiredArgsConstructor
 public enum DocumentType {
 
-    DEBIT_NOTE("80", "ใบเพิ่มหนี้ (Debit note)"),
-    CREDIT_NOTE("81", "ใบลดหนี้ (Credit note)"),
-    INVOICE("380", "ใบแจ้งหนี้ (Invoice)"),
-    TAX_INVOICE("388", "ใบกำกับภาษี (Tax Invoice)"),
-    RECEIPT("T01", "ใบรับ (Receipt)"),
-    INVOICE_AND_TAX_INVOICE("T02", "ใบแจ้งหนี้/ใบกำกับภาษี (Invoice/ Tax Invoice)"),
-    RECEIPT_TAX_INVOICE("T03", "ใบเสร็จรับเงิน/ใบกํากับภาษี (Receipt/ Tax Invoice)"),
-    DELIVERY_AND_TAX_INVOICE("T04", "ใบส่งของ/ใบกํากับภําษี (Delivery order/ Tax Invoice)"),
-    ABBREVIATED_TAX_INVOICE("T05", "ใบกํากับภําษีอย่ํางย่อ (Abbreviated Tax Invoice)"),
-    RECEIPT_AND_ABBREVIATED_TAX_INVOICE("T06", "ใบเสร็จรับเงิน/ใบกํากับภําษีอย่างย่อ (Receipt/Abbreviated Tax Invoice)"),
-    CANCELLATION_NOTE("T07", "ใบแจ้งยกเลิก (Cancellation note)");
+    DEBIT_NOTE("80", "ใบเพิ่มหนี้", "Debit Note"),
+
+    CREDIT_NOTE("81", "ใบลดหนี้", "Credit Note"),
+
+    INVOICE("380", "ใบแจ้งหนี้", "Invoice"),
+
+    TAX_INVOICE("388", "ใบกำกับภาษี", "Tax Invoice"),
+
+    RECEIPT("T01", "ใบรับ", "Receipt"),
+
+    INVOICE_AND_TAX_INVOICE("T02", "ใบแจ้งหนี้/ใบกำกับภาษี", "Invoice / Tax Invoice"),
+
+    RECEIPT_TAX_INVOICE("T03", "ใบเสร็จรับเงิน/ใบกํากับภาษี", "Receipt / Tax Invoice"),
+
+    DELIVERY_AND_TAX_INVOICE("T04", "ใบส่งของ/ใบกํากับภําษี", "Delivery order / Tax Invoice"),
+
+    ABBREVIATED_TAX_INVOICE("T05", "ใบกํากับภาษีอย่างย่อ", "Abbreviated Tax Invoice"),
+
+    RECEIPT_AND_ABBREVIATED_TAX_INVOICE("T06", "ใบเสร็จรับเงิน/ใบกํากับภาษีอย่างย่อ", "Receipt / Abbreviated Tax Invoice"),
+
+    CANCELLATION_NOTE("T07", "ใบแจ้งยกเลิก", "Cancellation note");
 
     public final String typeCode;
-    public final String description;
+    public final String thaiName;
+    public final String englishName;
 
-    public static Option<DocumentType> from(String typeCode) {
-        return getDocumentTypes().find($ -> $.typeCode.equals(typeCode));
+    @JsonCreator
+    public static DocumentType decode(String typeCode) {
+        return List.of(DocumentType.values())
+            .find($ -> $.typeCode.equals(typeCode))
+            .get();
     }
 
-    public static List<DocumentType> getDocumentTypes() {
-        return List.of(DocumentType.values());
+    public String getName() {
+        return format("%s (%s)", thaiName, englishName);
     }
 
 }

--- a/src/main/java/th/ac/kmitl/soa/group2/forms/HeaderForm.java
+++ b/src/main/java/th/ac/kmitl/soa/group2/forms/HeaderForm.java
@@ -16,7 +16,7 @@ public class HeaderForm implements BaseForm<HeaderModel> {
     public String id;
 
     @NotNull
-    public String typeCode;
+    public DocumentType documentType;
 
     @NotNull
     public Timestamp issuedAt;
@@ -31,8 +31,8 @@ public class HeaderForm implements BaseForm<HeaderModel> {
     public HeaderModel toModel() {
         return new HeaderModel(
             id,
-            DocumentType.from(typeCode).get().typeCode,
-            typeCode,
+            documentType.getName(),
+            documentType.typeCode,
             issuedAt,
             Option.some("dummy purpose"),
             purposeCode,


### PR DESCRIPTION
With custom decoder, we can abstract over enum type in forms with this:
``` java
public DocumentType documentType;
```

Instead of:
``` java
public String documentTypeCode;
```